### PR TITLE
Fix building with ffmpeg 4.3 and newer

### DIFF
--- a/src/device/videothread.cpp
+++ b/src/device/videothread.cpp
@@ -167,7 +167,7 @@ VideoThread::h264VideoStreamIndex()
 		if(m_avStream->codecpar->codec_type != AVMEDIA_TYPE_VIDEO)
 			continue;
 
-		AVCodec *dec = avcodec_find_decoder(m_avStream->codecpar->codec_id);
+		auto dec = avcodec_find_decoder(m_avStream->codecpar->codec_id);
 		if(!dec) {
 			qDebug() << "FRAMEBUFFER can't find decoder for stream" << i;
 			continue;


### PR DESCRIPTION
Fixes building with newer ffmpeg.

```
/tmp/DivvyDroid/src/device/videothread.cpp: In member function ‘int VideoThread::h264VideoStreamIndex()’:
/tmp/DivvyDroid/src/device/videothread.cpp:170:52: error: invalid conversion from ‘const AVCodec*’ to ‘AVCodec*’ [-fpermissive]
  170 |                 AVCodec *dec = avcodec_find_decoder(m_avStream->codecpar->codec_id);
      |                                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                    |
      |                                                    const AVCodec*
```

---

Similar issue resolved in some other project:
* https://github.com/dmlc/decord/pull/160/commits/b67c5268d8f4fa1f8302b0c4f69a008148f5cce9
* https://github.com/dmlc/decord/issues/155

---

Change tested with recent archlinux, ffmpeg 5.0 and android 10/11

---

Thx for this project, seems to be more reliable than scrcpy thanks to many fallbacks